### PR TITLE
Simplify ROS2 package setup for converted URDF packages from sw2urdf tool

### DIFF
--- a/conversion_urdf_ros_2_ros2.py
+++ b/conversion_urdf_ros_2_ros2.py
@@ -122,6 +122,15 @@ class ConversionApp:
         # Create folders
         run_command_dir(self.target_dir, "mkdir launch meshes meshes/collision meshes/visual urdf")
 
+        # Create resource and python package folders
+        run_command_dir(self.target_dir, f"mkdir resource {package_name}")
+
+        # Create resource/package_name file
+        open(f"{self.target_dir}resource/{package_name}", "w").close()
+
+        # Create __init__.py inside package folder
+        open(f"{self.target_dir}{package_name}/__init__.py", "w").close()
+
         # Copy files
         # Copy stl files
         run_command_dir(self.source_dir, f"cp -r ./meshes/* {self.target_dir}meshes/visual")


### PR DESCRIPTION
This PR improves the conversion workflow by automatically generating the required ROS2 Python package structure inside the selected target package directory.

Currently, users must manually create:

* resource/<package_name>
* <package_name>/**init**.py
* the Python module directory itself

If these are missing, colcon build can fail because the package is not recognized properly as a ROS2 Python package.

This change automates the creation of:

* resource directory
* Python package directory
* empty resource/<package_name> file
* **init**.py

The goal is to reduce setup friction and improve usability for users performing SolidWorks URDF to ROS2 conversion.
